### PR TITLE
Allow user to change plugin mapping

### DIFF
--- a/doc/Ark.txt
+++ b/doc/Ark.txt
@@ -30,7 +30,7 @@ It also provides a file running functionnality.
 =======================================================================
 Section 2: Mappings										  *ArkMappings*
 
-You can define the key used to compile and run the file in the current
+You can define the mapping used to compile and run the file in the current
 buffer with the global variable "g:ark_run_map". The default value is
 "<localleader>r".
 

--- a/doc/Ark.txt
+++ b/doc/Ark.txt
@@ -6,7 +6,7 @@
 					  | |  /_/   \_\_|  |_|\_\|____/ \___|_|  |_| .__/ \__|  | | ~
 					   \_\                                    |_|           /_/ ~
 
-						Functionnality for ArkScript programming language
+						Functionality for ArkScript programming language
 						 Syntax highlighting and file running inside Vim.
 
 =======================================================================
@@ -30,7 +30,9 @@ It also provides a file running functionnality.
 =======================================================================
 Section 2: Mappings										  *ArkMappings*
 
-<localleader>r : Run the file you have loaded in buffer
+You can define the key used to compile and run the file in the current
+buffer with the global variable "g:ark_run_map". The default value is
+"<localleader>r".
 
 =======================================================================
 Section 3: License										   *ArkLicense*
@@ -52,6 +54,9 @@ Make a pull request on the repository.
 
 =======================================================================
 Section 6:	Changelog                                     *ArkChangelog* 
+
+0.1.1 : Allow users to change the mapping to run the file in the current
+buffer
 
 0.1.0 : Syntax highlighting for builtin functions, operators, strings,
 comments and keywords

--- a/ftplugin/ark/running.vim
+++ b/ftplugin/ark/running.vim
@@ -4,7 +4,7 @@ endif
 
 function! ArkCompileAndRunFile()
 	silent !clear
-	execute "!" . g:ark_command . " " . bufname("%")
+	execute "!" . g:ark_command . " " . expand("%")
 endfunction
 
 nnoremap <buffer> <localleader>r :call ArkCompileAndRunFile()<cr>

--- a/ftplugin/ark/running.vim
+++ b/ftplugin/ark/running.vim
@@ -2,9 +2,13 @@ if !exists("g:ark_command")
 	let g:ark_command = "ark"
 endif
 
-function! ArkCompileAndRunFile()
+if !exists("g:ark_compile_and_run")
+	let g:ark_run_map = "<localleader>r"
+endif
+
+function! ArkCompileAndRunFile() abort
 	silent !clear
 	execute "!" . g:ark_command . " " . expand("%")
 endfunction
 
-nnoremap <buffer> <localleader>r :call ArkCompileAndRunFile()<cr>
+exec "nnoremap <buffer> " . g:ark_run_map . " :call ArkCompileAndRunFile()<cr>"

--- a/ftplugin/ark/running.vim
+++ b/ftplugin/ark/running.vim
@@ -2,7 +2,7 @@ if !exists("g:ark_command")
 	let g:ark_command = "ark"
 endif
 
-if !exists("g:ark_compile_and_run")
+if !exists("g:ark_run_map")
 	let g:ark_run_map = "<localleader>r"
 endif
 


### PR DESCRIPTION
Adds ability for the user to change the mapping for the plugin by setting the `g:ark_run_map` global variable, defaults to `<localleader>r`.